### PR TITLE
fix exit borrow syntax of EventWriter

### DIFF
--- a/rmf_sandbox/src/lib.rs
+++ b/rmf_sandbox/src/lib.rs
@@ -259,7 +259,7 @@ fn egui_ui(
     materials: ResMut<Assets<StandardMaterial>>,
     asset_server: Res<AssetServer>,
     mut active_camera_3d: ResMut<ActiveCamera<Camera3d>>,
-    exit: EventWriter<AppExit>,
+    mut exit: EventWriter<AppExit>,
 ) {
     let mut controls = query.single_mut();
     egui::TopBottomPanel::top("top_panel")


### PR DESCRIPTION
an EventWriter needs to be `mut` in order to send events. I don't know how this compiled before :shrug: 

Signed-off-by: Morgan Quigley <morgan@osrfoundation.org>