### PR TITLE
use ECS for spawn events, rather than OOP methods

### DIFF
--- a/rmf_sandbox/src/ui_widgets.rs
+++ b/rmf_sandbox/src/ui_widgets.rs
@@ -14,22 +14,17 @@ use bevy::{
 
 use bevy_egui::{egui, EguiContext, EguiPlugin};
 use super::camera_controls::{CameraControls, ProjectionMode};
-use super::site_map::{SiteMap};
+use super::site_map::{SpawnSiteMapYaml};
 use rfd::AsyncFileDialog;
 use futures_lite::future;
 
 fn egui_ui(
-    mut sm: ResMut<SiteMap>,
     mut egui_context: ResMut<EguiContext>,
     mut query: Query<&mut CameraControls>,
     mut commands: Commands,
-    meshes: ResMut<Assets<Mesh>>,
-    materials: ResMut<Assets<StandardMaterial>>,
-    asset_server: Res<AssetServer>,
     mut active_camera_3d: ResMut<ActiveCamera<Camera3d>>,
     mut _exit: EventWriter<AppExit>,
     thread_pool: Res<AsyncComputeTaskPool>,
-    mesh_query: Query<(Entity, &Handle<Mesh>)>,
 ) {
     let mut controls = query.single_mut();
     egui::TopBottomPanel::top("top_panel")
@@ -37,31 +32,22 @@ fn egui_ui(
             ui.vertical(|ui| {
 
                 egui::menu::bar(ui, |ui| {
+                    // File menu commands only make sense for non-web builds:
+                    #[cfg(not(target_arch = "wasm32"))]
                     egui::menu::menu_button(ui, "File", |ui| {
-                        if ui.button("Load demo").clicked() {
-                            sm.clear();
-                            sm.load_demo();
-                            sm.spawn(commands, meshes, materials, asset_server, mesh_query);
+                        if ui.button("Open...").clicked() {
+                            let future = thread_pool.spawn(async move {
+                                let file = AsyncFileDialog::new().pick_file().await;
+                                let data = match file {
+                                    Some(data) => Some(data.read().await),
+                                    None => None
+                                };
+                                data
+                            });
+                            commands.spawn().insert(future);
                         }
-                        else {
-                            // menu commands that only make sense for non-web builds:
-                            #[cfg(not(target_arch = "wasm32"))]
-                            {
-                                if ui.button("Open...").clicked() {
-                                    let future = thread_pool.spawn(async move {
-                                        let file = AsyncFileDialog::new().pick_file().await;
-                                        let data = match file {
-                                            Some(data) => Some(data.read().await),
-                                            None => None
-                                        };
-                                        data
-                                    });
-                                    commands.spawn().insert(future);
-                                }
-                                if ui.button("Quit").clicked() {
-                                    _exit.send(AppExit);
-                                }
-                            }
+                        if ui.button("Quit").clicked() {
+                            _exit.send(AppExit);
                         }
                     });
                 });
@@ -85,32 +71,26 @@ fn egui_ui(
 /// Handles the file opening events
 #[cfg(not(target_arch = "wasm32"))]
 fn handle_file_open(
-    mut sm: ResMut<SiteMap>,
     mut commands: Commands,
-    _meshes: ResMut<Assets<Mesh>>,
-    _materials: ResMut<Assets<StandardMaterial>>,
-    _asset_server: Res<AssetServer>,
     mut tasks: Query<(Entity, &mut Task<Option<Vec<u8>>>)>,
-    _mesh_query: Query<(Entity, &Handle<Mesh>)>,
+    mut spawn_yaml_writer: EventWriter<SpawnSiteMapYaml>,
 ) {
-
-    let mut assets_changed = false;
     for (entity, mut task) in tasks.iter_mut() {
         if let Some(result) = future::block_on(future::poll_once(&mut *task)) {
             match result {
                 Some(result) => {
-                    sm.clear();
-                    sm.load_yaml_from_data(&result);
-                    assets_changed =true;
+                    // success! Now, try to parse this file as YAML and spawn
+                    let yaml_result: serde_yaml::Result<serde_yaml::Value> =
+                        serde_yaml::from_slice(&result);
+                    match yaml_result {
+                        Ok(doc) => spawn_yaml_writer.send(SpawnSiteMapYaml { yaml_doc: doc }),
+                        Err(e) => println!("error parsing file: {:?}", e),
+                    }
                     commands.entity(entity).remove::<Task<Option<Vec<u8>>>>();
                 },
                 None => {}
             }
         }
-    }
-
-    if assets_changed {
-        sm.spawn(commands, _meshes, _materials, _asset_server, _mesh_query);
     }
 }
 
@@ -122,8 +102,6 @@ impl Plugin for UIWidgetsPlugin{
            .add_system(egui_ui);
 
         #[cfg(not(target_arch = "wasm32"))]
-        {
-            app.add_system(handle_file_open);
-        }
+        app.add_system(handle_file_open);
     }
 }


### PR DESCRIPTION
Eliminate the global `SiteMap` resource and use Bevy ECS events to issue spawn requests, rather than an "OOP-like" method call. This lets us clean up lots of unnecessary system parameters throughout a few files.

Signed-off-by: Morgan Quigley <morgan@osrfoundation.org>