### PR TITLE
don't display quit button in web build

### DIFF
--- a/rmf_sandbox/src/ui_widgets.rs
+++ b/rmf_sandbox/src/ui_widgets.rs
@@ -100,11 +100,10 @@ fn egui_ui(
                         visible_windows.welcome = false;
                         input_suppression.should_suppress = false;
                     }
-                }
-
-                ui.add_space(10.);
-                if ui.button("Quit").clicked() {
-                    _exit.send(AppExit);
+                    ui.add_space(10.);
+                    if ui.button("Quit").clicked() {
+                        _exit.send(AppExit);
+                    }
                 }
 
                 /*


### PR DESCRIPTION
Don't render quit button when building for web, since it doesn't make sense; programs in the WASM sandbox can't close the browser.

Signed-off-by: Morgan Quigley <morgan@osrfoundation.org>