### PR TITLE
until we set up https on model server, don't fetch from WASM

### DIFF
--- a/rmf_sandbox/src/model.rs
+++ b/rmf_sandbox/src/model.rs
@@ -26,26 +26,31 @@ impl Model {
         transform: &LevelTransform,
         asset_server: &Res<AssetServer>,
     ) {
-        let bundle_path = String::from("http://models.sandbox.open-rmf.org/models/")
-            + &self.model_name
-            + &String::from(".glb#Scene0");
-        println!(
-            "spawning {} at {}, {}",
-            &bundle_path, self.x_meters, self.y_meters
-        );
-        let glb = asset_server.load(&bundle_path);
-        commands
-            .spawn_bundle((
-                Transform {
-                    rotation: Quat::from_rotation_z(self.yaw as f32),
-                    translation: Vec3::new(self.x_meters as f32, self.y_meters as f32, 0.),
-                    scale: Vec3::ONE,
-                },
-                GlobalTransform::identity(),
-            ))
-            .with_children(|parent| {
-                parent.spawn_scene(glb);
-            });
+        // TODO: need to set up https on this server, for this WASM to work
+        // when hosted over https
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            let bundle_path = String::from("http://models.sandbox.open-rmf.org/models/")
+                + &self.model_name
+                + &String::from(".glb#Scene0");
+            println!(
+                "spawning {} at {}, {}",
+                &bundle_path, self.x_meters, self.y_meters
+            );
+            let glb = asset_server.load(&bundle_path);
+            commands
+                .spawn_bundle((
+                    Transform {
+                        rotation: Quat::from_rotation_z(self.yaw as f32),
+                        translation: Vec3::new(self.x_meters as f32, self.y_meters as f32, 0.),
+                        scale: Vec3::ONE,
+                    },
+                    GlobalTransform::identity(),
+                ))
+                .with_children(|parent| {
+                    parent.spawn_scene(glb);
+                });
+        }
     }
 
     pub fn from_yaml(value: &serde_yaml::Value) -> Model {


### PR DESCRIPTION
Until the model server is up on https, we can't download them over http when the WASM is hosted on GitHub Pages over https

Signed-off-by: Morgan Quigley <morgan@osrfoundation.org>