### PR TITLE
use albedo and roughness map for warehouse floor material

### DIFF
--- a/rmf_sandbox/src/camera_controls.rs
+++ b/rmf_sandbox/src/camera_controls.rs
@@ -208,7 +208,7 @@ fn handle_keyboard(
 fn camera_controls_setup(mut commands: Commands) {
     let proj_entity = commands
         .spawn_bundle(PerspectiveCameraBundle {
-            transform: Transform::from_xyz(0., 0., 20.).looking_at(Vec3::ZERO, Vec3::Y),
+            transform: Transform::from_xyz(-10., -10., 10.).looking_at(Vec3::ZERO, Vec3::Z),
             ..default()
         })
         .id();
@@ -231,7 +231,7 @@ fn camera_controls_setup(mut commands: Commands) {
             perspective_camera_entity: proj_entity,
             orthographic_camera_entity: ortho_entity,
             orbit_center: Vec3::ZERO,
-            orbit_radius: 20.0,
+            orbit_radius: (3.0 * 10.0 * 10.0 as f32).sqrt(),
             orbit_upside_down: false,
         },
     });

--- a/rmf_sandbox/src/site_map.rs
+++ b/rmf_sandbox/src/site_map.rs
@@ -11,6 +11,7 @@ use bevy_egui::EguiContext;
 use bevy_inspector_egui::plugin::InspectorWindows;
 use bevy_inspector_egui::{Inspectable, InspectorPlugin, RegisterInspectable};
 use bevy_mod_picking::{DefaultPickingPlugins, PickingBlocker, PickingCamera, PickingCameraBundle};
+use std::collections::HashMap;
 
 use std::{
     env,
@@ -31,6 +32,11 @@ pub enum Editable {
     Measurement(Measurement),
     Vertex(Vertex),
     Wall(Wall),
+}
+
+#[derive(Default)]
+pub struct MaterialMap {
+    pub materials: HashMap<String, Handle<StandardMaterial>>,
 }
 
 ////////////////////////////////////////////////////////
@@ -325,6 +331,7 @@ impl Plugin for SiteMapPlugin {
             .add_plugin(InspectorPlugin::<Inspector>::new())
             .register_inspectable::<Lane>()
             .init_resource::<Handles>()
+            .init_resource::<MaterialMap>()
             .add_startup_system(init_handles)
             .add_event::<SpawnSiteMap>()
             .add_event::<SpawnSiteMapFilename>()

--- a/rmf_sandbox/src/ui_widgets.rs
+++ b/rmf_sandbox/src/ui_widgets.rs
@@ -1,7 +1,5 @@
 use super::camera_controls::{CameraControls, ProjectionMode};
-use super::level::Level;
-use super::site_map::{Handles, SpawnSiteMapYaml};
-use super::vertex::Vertex;
+use super::site_map::SpawnSiteMapYaml;
 use super::warehouse_generator::{warehouse_ui, WarehouseState};
 use bevy::{
     app::AppExit,


### PR DESCRIPTION
* use concrete albedo and roughness maps for warehouse-generator floor material
* start the 3D camera in a lower angle

Signed-off-by: Morgan Quigley <morgan@osrfoundation.org>