### PR TITLE
reduce console spew, so it's easier to debug new features

### DIFF
--- a/rmf_sandbox/src/despawn.rs
+++ b/rmf_sandbox/src/despawn.rs
@@ -73,7 +73,6 @@ fn despawn_system(
         commands.entity(*e).despawn_recursive();
         despawned.send(Despawned(*e));
         done.push(*e);
-        println!("despawned entity {},{}", e.id(), e.generation());
     }
     for e in done {
         to_despawn.remove(&e);

--- a/rmf_sandbox/src/site_map.rs
+++ b/rmf_sandbox/src/site_map.rs
@@ -420,10 +420,6 @@ fn update_models(
         for (e, model) in added_models.iter() {
             let bundle_path =
                 String::from("sandbox://") + &model.model_name + &String::from(".glb#Scene0");
-            println!(
-                "spawning {} at {}, {}",
-                &bundle_path, model.x_meters, model.y_meters
-            );
             let glb: Handle<Scene> = asset_server.load(&bundle_path);
             commands.entity(e).insert(DespawnBlocker());
             loading_models.insert(e, (model.clone(), glb.clone()));


### PR DESCRIPTION
Removes a bunch of `println!()` calls of things that are working now, so that the console is "free" for new features to print stuff.