### PR TITLE
RFC: use directional light that follows the camera

### DIFF
--- a/rmf_sandbox/src/camera_controls.rs
+++ b/rmf_sandbox/src/camera_controls.rs
@@ -1,3 +1,4 @@
+use crate::settings::*;
 use bevy::{
     input::mouse::{MouseButton, MouseWheel},
     prelude::*,
@@ -205,23 +206,25 @@ fn handle_keyboard(
     }
 }
 
-fn camera_controls_setup(mut commands: Commands) {
-    let proj_entity = commands
-        .spawn_bundle(PerspectiveCameraBundle {
-            transform: Transform::from_xyz(-10., -10., 10.).looking_at(Vec3::ZERO, Vec3::Z),
-            ..default()
-        })
-        .with_children(|parent| {
+fn camera_controls_setup(mut commands: Commands, settings: Res<Settings>) {
+    let mut builder = commands.spawn_bundle(PerspectiveCameraBundle {
+        transform: Transform::from_xyz(-10., -10., 10.).looking_at(Vec3::ZERO, Vec3::Z),
+        ..default()
+    });
+    // When graphics is low, use a directional light that follows the camera.
+    if settings.graphics_quality == GraphicsQuality::Low {
+        builder.with_children(|parent| {
             parent.spawn_bundle(DirectionalLightBundle {
                 directional_light: DirectionalLight {
                     shadows_enabled: false,
-                    illuminance: 20000.,
+                    illuminance: 15000.,
                     ..default()
                 },
                 ..default()
             });
-        })
-        .id();
+        });
+    }
+    let proj_entity = builder.id();
 
     let ortho_entity = commands
         .spawn_bundle(OrthographicCameraBundle {

--- a/rmf_sandbox/src/lib.rs
+++ b/rmf_sandbox/src/lib.rs
@@ -10,6 +10,9 @@ use bevy::{core::FixedTimestep, window::Windows};
 
 extern crate web_sys;
 
+mod settings;
+use settings::*;
+
 mod camera_controls;
 mod demo_world;
 mod despawn;
@@ -59,42 +62,35 @@ fn check_browser_window_size(mut windows: ResMut<Windows>) {
 
 #[wasm_bindgen]
 pub fn run() {
+    let mut app = App::new();
+
     #[cfg(target_arch = "wasm32")]
-    App::new()
-        .insert_resource(WindowDescriptor {
+    {
+        app.insert_resource(WindowDescriptor {
             title: "RMF Sandbox".to_string(),
             canvas: Some(String::from("#rmf_sandbox_canvas")),
             //vsync: false,
             ..Default::default()
         })
-        .add_state(AppState::MainMenu)
-        .add_plugins_with(DefaultPlugins, |group| {
-            group.add_before::<bevy::asset::AssetPlugin, _>(SandboxAssetIoPlugin)
-        })
-        .insert_resource(DirectionalLightShadowMap { size: 1024 })
-        .add_plugin(bevy_egui::EguiPlugin)
-        .add_plugin(MainMenuPlugin)
-        .add_plugin(SiteMapPlugin)
-        .add_plugin(CameraControlsPlugin)
-        .add_plugin(TrafficEditorPlugin)
-        .add_plugin(WarehouseGeneratorPlugin)
-        .add_plugin(DespawnPlugin)
         .add_system_set(
             SystemSet::new()
                 .with_run_criteria(FixedTimestep::step(0.5))
                 .with_system(check_browser_window_size),
-        )
-        .run();
+        );
+    }
 
     #[cfg(not(target_arch = "wasm32"))]
-    App::new()
-        .insert_resource(WindowDescriptor {
+    {
+        app.insert_resource(WindowDescriptor {
             title: "RMF Sandbox".to_string(),
             width: 1600.,
             height: 900.,
             //vsync: false,
             ..Default::default()
-        })
+        });
+    }
+
+    app.init_resource::<Settings>()
         .insert_resource(DirectionalLightShadowMap { size: 2048 })
         .add_plugins_with(DefaultPlugins, |group| {
             group.add_before::<bevy::asset::AssetPlugin, _>(SandboxAssetIoPlugin)

--- a/rmf_sandbox/src/settings.rs
+++ b/rmf_sandbox/src/settings.rs
@@ -1,0 +1,18 @@
+pub struct Settings {
+    pub graphics_quality: GraphicsQuality,
+}
+
+impl Default for Settings {
+    fn default() -> Self {
+        Self {
+            // todo: select based on WASM and GPU (or not)
+            graphics_quality: GraphicsQuality::Low,
+        }
+    }
+}
+
+#[derive(PartialEq)]
+pub enum GraphicsQuality {
+    Low,
+    Ultra,
+}


### PR DESCRIPTION
The current lighting does not work when viewed from different angles.

https://user-images.githubusercontent.com/45189696/170183021-7fdf47c5-e7c8-40c4-b093-57b4c0218147.mp4

I think there is a WIP(?) solution which creates a grid of lights to illuminate the map, this PR presents an alternative, simpler approach by simply tying the light source to the camera so that the area currently being seen is already illuminated.

https://user-images.githubusercontent.com/45189696/170183499-7e9feb86-10d3-4c28-af52-be84d35b118d.mp4

I am not knowledgable enough about 3d rendering to know the pros and cons of these approaches, I guess the light grid will produce a more realistic render, with the downside that it is more much complex and require more cpu/gpu powers.