### PR TITLE
Improve spawning system

### DIFF
--- a/rmf_sandbox/src/building_map.rs
+++ b/rmf_sandbox/src/building_map.rs
@@ -4,7 +4,7 @@ use std::collections::BTreeMap;
 use crate::crowd_sim::CrowdSim;
 use crate::level::Level;
 
-#[derive(Deserialize, Serialize, Default)]
+#[derive(Deserialize, Serialize, Clone, Default)]
 pub struct BuildingMap {
     pub name: String,
     pub version: Option<i32>,

--- a/rmf_sandbox/src/camera_controls.rs
+++ b/rmf_sandbox/src/camera_controls.rs
@@ -217,7 +217,7 @@ fn camera_controls_setup(mut commands: Commands, settings: Res<Settings>) {
             parent.spawn_bundle(DirectionalLightBundle {
                 directional_light: DirectionalLight {
                     shadows_enabled: false,
-                    illuminance: 15000.,
+                    illuminance: 20000.,
                     ..default()
                 },
                 ..default()

--- a/rmf_sandbox/src/save_load.rs
+++ b/rmf_sandbox/src/save_load.rs
@@ -37,7 +37,7 @@ fn save(world: &mut World) {
     println!("Saving to {}", path.to_str().unwrap());
 
     let mut state: SystemState<(
-        Res<SiteMapRoot>,
+        Res<Option<SiteMapRoot>>,
         Query<&Children>,
         Query<&CrowdSim>,
         Query<&LevelExtra>,
@@ -64,11 +64,18 @@ fn save(world: &mut World) {
         mut q_walls,
         q_models,
     ) = state.get_mut(world);
+    let root_entity = match &*root_entity {
+        Some(root_entity) => root_entity.0,
+        None => {
+            println!("ERROR: Cannot save map (no map found)");
+            return;
+        }
+    };
 
-    let crowd_sim = q_crowd_sim.get(root_entity.0).unwrap().clone();
+    let crowd_sim = q_crowd_sim.get(root_entity).unwrap().clone();
     let mut levels: BTreeMap<String, Level> = BTreeMap::new();
 
-    for level in q_children.get(root_entity.0).unwrap().into_iter() {
+    for level in q_children.get(root_entity).unwrap().into_iter() {
         let mut vertices: Vec<Vertex> = Vec::new();
         let mut lanes: Vec<Lane> = Vec::new();
         let mut measurements: Vec<Measurement> = Vec::new();
@@ -131,7 +138,7 @@ fn save(world: &mut World) {
     }
 
     let map = BuildingMap {
-        name: q_name.get(root_entity.0).unwrap().0.clone(),
+        name: q_name.get(root_entity).unwrap().0.clone(),
         version: Some(2),
         crowd_sim: crowd_sim.clone(),
         levels,
@@ -144,5 +151,53 @@ impl Plugin for SaveLoadPlugin {
     fn build(&self, app: &mut App) {
         app.add_event::<SaveMap>()
             .add_system(save.exclusive_system());
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::spawner::*;
+
+    #[test]
+    fn test_save() -> Result<(), Box<dyn std::error::Error>> {
+        let mut app = App::new();
+        app.add_plugin(SaveLoadPlugin)
+            .add_plugin(SpawnerPlugin)
+            .add_plugin(crate::despawn::DespawnPlugin);
+
+        let buffer = std::fs::read("assets/demo_maps/office.building.yaml").unwrap();
+        let map = BuildingMap::from_bytes(&buffer).unwrap();
+        let cap_map = map.clone();
+        app.add_system(move |mut spawner: Spawner, mut ran: Local<bool>| {
+            if *ran {
+                return;
+            }
+            spawner.spawn_map(&cap_map);
+            *ran = true;
+        });
+        app.update();
+
+        app.world
+            .resource_mut::<Events<SaveMap>>()
+            .send(SaveMap(PathBuf::from("test_output/save_map.yaml")));
+        app.update();
+
+        let buffer = std::fs::read("assets/demo_maps/office.building.yaml").unwrap();
+        let new_map = BuildingMap::from_bytes(&buffer).unwrap();
+
+        assert!(new_map.levels.len() == map.levels.len());
+        for (new_map, original_map) in new_map.levels.into_iter().zip(map.levels.into_iter()) {
+            // good enough to check that nothing is missing, checking if all values are correct
+            // would be quite complicated as units will be converted and items may be re-keyed.
+            assert!(new_map.0 == original_map.0);
+            assert!(new_map.1.vertices.len() == original_map.1.vertices.len());
+            assert!(new_map.1.lanes.len() == original_map.1.lanes.len());
+            assert!(new_map.1.measurements.len() == original_map.1.measurements.len());
+            assert!(new_map.1.walls.len() == original_map.1.walls.len());
+            assert!(new_map.1.models.len() == original_map.1.models.len());
+        }
+
+        Ok(())
     }
 }

--- a/rmf_sandbox/src/save_load.rs
+++ b/rmf_sandbox/src/save_load.rs
@@ -37,7 +37,7 @@ fn save(world: &mut World) {
     println!("Saving to {}", path.to_str().unwrap());
 
     let mut state: SystemState<(
-        Res<Option<SiteMapRoot>>,
+        Query<Entity, With<SiteMapRoot>>,
         Query<&Children>,
         Query<&CrowdSim>,
         Query<&LevelExtra>,
@@ -64,10 +64,10 @@ fn save(world: &mut World) {
         mut q_walls,
         q_models,
     ) = state.get_mut(world);
-    let root_entity = match &*root_entity {
-        Some(root_entity) => root_entity.0,
-        None => {
-            println!("ERROR: Cannot save map (no map found)");
+    let root_entity = match root_entity.get_single() {
+        Ok(root_entity) => root_entity,
+        Err(err) => {
+            println!("ERROR: Cannot save map ({})", err);
             return;
         }
     };

--- a/rmf_sandbox/src/save_load.rs
+++ b/rmf_sandbox/src/save_load.rs
@@ -162,7 +162,8 @@ mod test {
     #[test]
     fn test_save() -> Result<(), Box<dyn std::error::Error>> {
         let mut app = App::new();
-        app.add_plugin(SaveLoadPlugin)
+        app.add_plugin(HierarchyPlugin)
+            .add_plugin(SaveLoadPlugin)
             .add_plugin(SpawnerPlugin)
             .add_plugin(crate::despawn::DespawnPlugin);
 
@@ -183,7 +184,7 @@ mod test {
             .send(SaveMap(PathBuf::from("test_output/save_map.yaml")));
         app.update();
 
-        let buffer = std::fs::read("assets/demo_maps/office.building.yaml").unwrap();
+        let buffer = std::fs::read("test_output/save_map.yaml").unwrap();
         let new_map = BuildingMap::from_bytes(&buffer).unwrap();
 
         assert!(new_map.levels.len() == map.levels.len());

--- a/rmf_sandbox/src/spawner.rs
+++ b/rmf_sandbox/src/spawner.rs
@@ -168,8 +168,7 @@ pub struct SpawnerPlugin;
 
 impl Plugin for SpawnerPlugin {
     fn build(&self, app: &mut App) {
-        app.init_resource::<Option<SiteMapRoot>>()
-            .init_resource::<MapLevels>()
+        app.init_resource::<MapLevels>()
             .init_resource::<VerticesManagers>();
     }
 }


### PR DESCRIPTION
* Adds a basic test for serializing into yaml.
* Rework the despawner to be much simpler.
* `SiteMapRoot` is now a component instead of a resource, having it as a resource causes "use after despawn" problems where things still refer to the old entity after it is despawned.