### PR TITLE
Windows Tech Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ Finally, we need some library packages:
 sudo apt install libgtk-3-dev
 ```
 
+# Install dependencies (Windows 11)
+
+Make sure you install rust from the main rust website. Cargo should take care of the rest of the magic for you.
+
 # Install extra dependencies for WebAssembly
 
 These are only needed if you're going to build a WebAssembly binary:
@@ -53,7 +57,7 @@ rustup target add wasm32-unknown-unknown
 
 # Build and Run (Desktop)
 
-Currently only tested on Ubuntu 20.04.4 LTS.
+Currently tested on Ubuntu 20.04.4 LTS and windows 11.
 
 From the `rmf_sandbox` subdirectory:
 

--- a/rmf_sandbox/.cargo/config.toml
+++ b/rmf_sandbox/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.x86_64-pc-windows-msvc]
+rustflags = ["-Zshare-generics=off"]

--- a/rmf_sandbox/Cargo.toml
+++ b/rmf_sandbox/Cargo.toml
@@ -24,9 +24,14 @@ futures-lite = "1.12.0"
 bevy = { version = "0.7" }
 dirs = "4.0"
 
-# only enable the 'dynamic' feature if we're not building for web
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+# only enable the 'dynamic' feature if we're not building for web or windows
+[target.'cfg(all(not(target_arch = "wasm32"), not(target_os = "windows")))'.dependencies]
 bevy = { version = "0.7", features = ["dynamic"] }
+surf = { version = "2.3" }
+
+# windows doesnt work well with dynamic feature yet
+[target.'cfg(target_os = "windows")'.dependencies]
+bevy = { version = "0.7" }
 surf = { version = "2.3" }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]


### PR DESCRIPTION
This PR adds the ability to build on windows. All you need to do is build using the standard rust steps. Essentially Bevy's dynamic feature is not supported on windows. This PR disables the dynamic feature.

![Screenshot 2022-06-02 175405](https://user-images.githubusercontent.com/542272/171644841-ded1cb9a-a5ec-4c05-9fa4-2b045369e94f.png)
 