### PR TITLE
Fix picking through gui panels

### DIFF
--- a/rmf_sandbox/src/traffic_editor.rs
+++ b/rmf_sandbox/src/traffic_editor.rs
@@ -769,7 +769,9 @@ fn enable_picking(
     // Normally bevy_mod_picking automatically stops when
     // a bevy ui node is in focus, but bevy_egui does not use bevy ui node.
     let egui_ctx = egui_context.ctx_mut();
-    let enable = !egui_ctx.wants_pointer_input() && !egui_ctx.wants_keyboard_input() && !egui_ctx.is_pointer_over_area();
+    let enable = !egui_ctx.wants_pointer_input()
+        && !egui_ctx.wants_keyboard_input()
+        && !egui_ctx.is_pointer_over_area();
 
     let mut blocker = picking_blocker.single_mut();
     if enable {

--- a/rmf_sandbox/src/traffic_editor.rs
+++ b/rmf_sandbox/src/traffic_editor.rs
@@ -769,7 +769,7 @@ fn enable_picking(
     // Normally bevy_mod_picking automatically stops when
     // a bevy ui node is in focus, but bevy_egui does not use bevy ui node.
     let egui_ctx = egui_context.ctx_mut();
-    let enable = !egui_ctx.wants_pointer_input() && !egui_ctx.wants_keyboard_input();
+    let enable = !egui_ctx.wants_pointer_input() && !egui_ctx.wants_keyboard_input() && !egui_ctx.is_pointer_over_area();
 
     let mut blocker = picking_blocker.single_mut();
     if enable {
@@ -795,7 +795,7 @@ impl Plugin for TrafficEditorPlugin {
                     .before(SiteMapLabel)
                     .with_system(egui_ui)
                     .with_system(update_picking_cam)
-                    .with_system(enable_picking)
+                    .with_system(enable_picking.after(egui_ui))
                     .with_system(maintain_inspected_entities),
             );
     }


### PR DESCRIPTION
## Bug fix

### Fixed bug

The picking module was conflicting with `egui` and models behind the panel would be highlighted / selected when the user interacted with panels, making it almost impossible to interact with text boxes to change a model property (when clicking on it the model behind the panel would be selected, changing the panel itself).
Example video below:

https://user-images.githubusercontent.com/9111558/178931130-f894e92c-19bc-459b-bf1a-2827c6b1e58d.mp4

### Fix applied

It seems we should also use [is_pointer_over_area](https://docs.rs/egui/0.14.2/egui/struct.Context.html#method.is_pointer_over_area) to figure out whether we are on top of a egui area or not, that helped but made the bug happen "sometimes" i.e. consecutive `cargo run` would behave differently.
I suspected it might be due to the fact that systems are executed in parallel in bevy unless clear dependencies are specified and my hypothesis is that since picking depends on egui being updated it should be executed afterwards.
I added an explicit order by running `enable_picking` after the egui update and it seems to be fine, but this kind of issues can be tricky to figure out and "it works on my machine" might not be the best metric :man_shrugging: 

https://user-images.githubusercontent.com/9111558/178932355-6ae95d82-b6de-4c4c-9776-3a5ab72facad.mp4