### PR TITLE
Switch to stable Rust version, rather than a pegged nightly

### DIFF
--- a/.github/workflows/ci_web.yaml
+++ b/.github/workflows/ci_web.yaml
@@ -15,8 +15,6 @@ jobs:
 
     - name: rust-wasm-target
       run: |
-        rustup toolchain install nightly-2022-04-27
-        rustup default nightly-2022-04-27
         rustup target add wasm32-unknown-unknown
 
     - name: apt-deps

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -17,8 +17,6 @@ jobs:
 
     - name: rustfmt
       run: |
-        rustup toolchain install nightly-2022-04-27
-        rustup default nightly-2022-04-27
         rustup component add rustfmt
 
     - name: style

--- a/rmf_sandbox/rust-toolchain.toml
+++ b/rmf_sandbox/rust-toolchain.toml
@@ -1,2 +1,0 @@
-[toolchain]
-channel = "nightly-2022-04-27"


### PR DESCRIPTION
Back in April, there was a small regression in rust-nightly that required us to peg to nightly from a few days before. At that time, we needed to use rust-nightly because of some leading-edge features required by Bevy. This is no longer the case, and I think we'll benefit from returning to the stable version.

As another benefit, by returning to the stable toolchain, we will no longer require manual installation of a particular nightly toolchain for the WASM build.

Signed-off-by: Morgan Quigley <morgan@osrfoundation.org>