### PR TITLE
return to normal rust-nightly, not a specific date

### DIFF
--- a/.github/workflows/ci_web.yaml
+++ b/.github/workflows/ci_web.yaml
@@ -15,8 +15,8 @@ jobs:
 
     - name: rust-wasm-target
       run: |
-        rustup toolchain install nightly-2022-04-27
-        rustup default nightly-2022-04-27
+        rustup toolchain install nightly
+        rustup default nightly
         rustup target add wasm32-unknown-unknown
 
     - name: apt-deps

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -17,8 +17,8 @@ jobs:
 
     - name: rustfmt
       run: |
-        rustup toolchain install nightly-2022-04-27
-        rustup default nightly-2022-04-27
+        rustup toolchain install nightly
+        rustup default nightly
         rustup component add rustfmt
 
     - name: style

--- a/rmf_sandbox/rust-toolchain.toml
+++ b/rmf_sandbox/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly-2022-04-27"
+channel = "nightly"


### PR DESCRIPTION
Back in April 2022, there was a minor regression in rust-nightly that forced us to peg the date of our toolchain. That has long since been fixed, so we can now return to "normal" Rust nightly. This will make the toolchain installation instructions for the WASM versions actually work again :tada: 

Signed-off-by: Morgan Quigley <morgan@osrfoundation.org>