### PR TITLE
Adds a simulation preview button

### DIFF
--- a/rmf_sandbox/src/lib.rs
+++ b/rmf_sandbox/src/lib.rs
@@ -43,6 +43,7 @@ mod measurement;
 mod model;
 mod rbmf;
 mod sandbox_asset_io;
+mod simulation_state;
 mod utils;
 mod vertex;
 mod wall;

--- a/rmf_sandbox/src/simulation_state.rs
+++ b/rmf_sandbox/src/simulation_state.rs
@@ -1,5 +1,4 @@
 #[derive(Default)]
-pub struct SimulationState
-{
-    pub paused: bool
+pub struct SimulationState {
+    pub paused: bool,
 }

--- a/rmf_sandbox/src/simulation_state.rs
+++ b/rmf_sandbox/src/simulation_state.rs
@@ -1,0 +1,5 @@
+#[derive(Default)]
+pub struct SimulationState
+{
+    pub paused: bool
+}

--- a/rmf_sandbox/src/traffic_editor.rs
+++ b/rmf_sandbox/src/traffic_editor.rs
@@ -11,6 +11,7 @@ use crate::lift::Lift;
 use crate::measurement::Measurement;
 use crate::model::Model;
 use crate::save_load::SaveMap;
+use crate::simulation_state::SimulationState;
 use crate::site_map::{SiteMapCurrentLevel, SiteMapLabel, SiteMapState};
 use crate::spawner::{Spawner, VerticesManagers};
 use crate::vertex::Vertex;
@@ -701,6 +702,7 @@ fn egui_ui(
     mut q_camera_controls: Query<&mut CameraControls>,
     mut cameras: Query<(&mut Camera, &mut Visibility)>,
     mut app_state: ResMut<State<AppState>>,
+    mut sim_state: ResMut<SimulationState>,
     mut editor: EditorPanel,
     opened_map_file: Option<Res<OpenedMapFile>>,
     map: Res<BuildingMap>,
@@ -737,6 +739,15 @@ fn egui_ui(
                     .clicked()
                 {
                     controls.use_perspective(true, &mut cameras);
+                }
+                if ui
+                    .add(egui::SelectableLabel::new(
+                        sim_state.paused,
+                        "Preview Simulation",
+                    ))
+                    .clicked()
+                {
+                    sim_state.paused = !sim_state.paused;
                 }
                 #[cfg(not(target_arch = "wasm32"))]
                 {
@@ -1329,6 +1340,7 @@ impl Plugin for TrafficEditorPlugin {
             .init_resource::<Option<SelectedEditable>>()
             .init_resource::<Option<HoveredEditable>>()
             .init_resource::<HasChanges>()
+            .init_resource::<SimulationState>()
             .add_event::<ElementDeleted>()
             .add_event::<Option<SelectedEditable>>()
             .add_event::<Option<HoveredEditable>>()


### PR DESCRIPTION
As part of my push towards visuallization of a crowd in rmf_sandbox, I am adding a "simulation preview" button. This button currently does nothing, however it enables a `SimulationState` resource. This will be needed when a user wants to preview the crowd simulations prior to running it in gazebo.

Signed-off-by: Arjo Chakravarty <arjo@openrobotics.org>