### PR TITLE
Only export each model instance to one level

### DIFF
--- a/crates/rmf_site_format/src/sdf.rs
+++ b/crates/rmf_site_format/src/sdf.rs
@@ -503,6 +503,10 @@ impl Site {
                 let parented_model_instance = self.model_instances.get(model_instance_id).ok_or(
                     SdfConversionError::BrokenModelInstanceReference(*model_instance_id),
                 )?;
+                if parented_model_instance.parent != *level_id {
+                    continue;
+                }
+
                 let Some(model_description_id) = parented_model_instance.bundle.description.0
                 else {
                     continue;


### PR DESCRIPTION
Complementary to #324, this PR prevents models from being exported to more than one level.

#324 did prevent duplicate versions of the robot entities from being spawned on each level, but we still have a problem where each non-static model instance will be exported to each floor no matter what its actual parent floor is because [this for-loop](https://github.com/open-rmf/rmf_site/blob/dbb2cc49d57cef6012f530832c2b8dd2cd379b95/crates/rmf_site_format/src/sdf.rs#L502) over each model instance is nested inside [this for-loop](https://github.com/open-rmf/rmf_site/blob/dbb2cc49d57cef6012f530832c2b8dd2cd379b95/crates/rmf_site_format/src/sdf.rs#L451) over each level.

This PR simply skips exporting instances to levels that they don't belong on. I expect this problem will be fixed differently by #326, but this PR is a minimal fix necessary for multi-floor support until #326 is done.

This PR combined with #319 allow the hotel world to be exported and simulated successfully on jazzy.