### PR TITLE
Always clear dependents from preview anchor

### DIFF
--- a/crates/rmf_site_editor/src/interaction/select_impl/create_edges.rs
+++ b/crates/rmf_site_editor/src/interaction/select_impl/create_edges.rs
@@ -17,7 +17,7 @@
 
 use crate::{
     interaction::*,
-    site::{ChangeDependent, Pending, TextureNeedsAssignment},
+    site::{ChangeDependent, Dependents, Pending, TextureNeedsAssignment},
 };
 use bevy::prelude::*;
 use bevy_impulse::*;
@@ -390,6 +390,8 @@ pub fn cleanup_create_edges(
     mut access: BufferAccessMut<CreateEdges>,
     edges: Query<&'static Edge<Entity>>,
     mut commands: Commands,
+    cursor: Res<Cursor>,
+    mut dependents: Query<&mut Dependents>,
 ) -> SelectionNodeResult {
     let mut access = access.get_mut(&key).or_broken_buffer()?;
     let state = access.pull().or_broken_state()?;
@@ -398,5 +400,14 @@ pub fn cleanup_create_edges(
         // We created a preview, so we should despawn it while cleaning up
         preview.cleanup(&edges, &mut commands)?;
     }
+
+    // NOTE(@mxgrey): We resort to this brute force approach as a stopgap measure for
+    // https://github.com/open-rmf/rmf_site/issues/398
+    if let Ok(mut deps) = dependents.get_mut(cursor.level_anchor_placement) {
+        // We're done trying to create edges, so just remove all lingering
+        // dependents from the preview anchor.
+        deps.0.clear();
+    }
+
     Ok(())
 }


### PR DESCRIPTION
#396 side-stepped a panic that would occur after deleting a newly created edge, but instead of panicking, the site editor would spam warning messages for the remainder of its run.

The ideal solution to the problem is described in #398, but that may take a considerable amount of thought and effort. In the meantime this PR takes a brute force approach to resolving the underlying problem by manually purging the preview anchor of any dependents during the cleanup phase of the edge creation mode.