### PR TITLE
Add Pending filter for ChildOf reassignment

### DIFF
--- a/crates/rmf_site_editor/src/site/level.rs
+++ b/crates/rmf_site_editor/src/site/level.rs
@@ -42,7 +42,7 @@ pub fn update_level_visibility(
 pub fn handle_on_level_change(
     trigger: Trigger<OnInsert, LastSetValue<OnLevel<Entity>>>,
     mut commands: Commands,
-    on_levels: Query<(Entity, &OnLevel<Entity>)>,
+    on_levels: Query<(Entity, &OnLevel<Entity>), Without<Pending>>,
     level_elevation: Query<(), With<LevelElevation>>,
 ) {
     if let Ok((entity, on_level)) = on_levels.get(trigger.target()) {


### PR DESCRIPTION
Closes https://github.com/open-rmf/rmf_site/issues/376.

Currently any model instance preview created from a model description with `ModelProperty<Robot>` wouldn't show up at the cursor until the cursor has clicked / model is placed in the site. This is due to the `ChildOf` reassignment for these pending models (specifically robots) from cursor frame entity to the current level entity. This causes the preview to be created at the origin.

This PR restricts only entities without `Pending` to have their parent entity reassigned based on `LastSetValue<OnLevel>` triggers.