### PR TITLE
Export site file as JSON on wasm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5683,6 +5683,7 @@ dependencies = [
  "geo",
  "gz-fuel",
  "itertools 0.11.0",
+ "js-sys",
  "mapf",
  "nalgebra 0.32.6",
  "pathdiff",
@@ -5707,6 +5708,7 @@ dependencies = [
  "urdf-rs",
  "utm",
  "uuid",
+ "wasm-bindgen",
  "web-sys",
  "web-time",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5707,6 +5707,7 @@ dependencies = [
  "urdf-rs",
  "utm",
  "uuid",
+ "web-sys",
  "web-time",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,7 @@ testdir = "0.9"
 file_diff = "1.0"
 web-sys = "0.3"
 web-time = "1"
+js-sys = "0.3"
 
 bevy = {version = "0.16", features = ["configurable_error_handler"]}
 bevy_a11y = "0.16"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,7 @@ bytemuck = {version = "1.22"}
 bevy_infinite_grid = { version = "0.15"}
 testdir = "0.9"
 file_diff = "1.0"
+web-sys = "0.3"
 web-time = "1"
 
 bevy = {version = "0.16", features = ["configurable_error_handler"]}

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Use the `--release` flag for better runtime performance.
 # Build and Run (WebAssembly)
 
 TODO: The web assembly version is highly experimental, currently it lacks important features like
-saving/loading of map files.
+saving/loading of map files. However, you may opt to export the JSON file via download or copy/paste.
 
 ```bash
 $ scripts/build-web.sh

--- a/crates/rmf_site_editor/Cargo.toml
+++ b/crates/rmf_site_editor/Cargo.toml
@@ -71,7 +71,9 @@ web-time = {workspace = true}
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 bevy_egui = { workspace = true, default-features = false, features = ["open_url", "default_fonts", "render"] }
 crossflow = { workspace = true, features = ["single_threaded_async"]}
-web-sys = { workspace = true, features = ["Clipboard", "Window", "Navigator"] }
+js-sys = { workspace = true }
+wasm-bindgen = { workspace = true }
+web-sys = { workspace = true, features = ["Clipboard", "Window", "Navigator", "Blob", "Url", "HtmlAnchorElement", "Document"] }
 web-time = {workspace = true}
 
 [dev-dependencies]

--- a/crates/rmf_site_editor/Cargo.toml
+++ b/crates/rmf_site_editor/Cargo.toml
@@ -71,6 +71,7 @@ web-time = {workspace = true}
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 bevy_egui = { workspace = true, default-features = false, features = ["open_url", "default_fonts", "render"] }
 crossflow = { workspace = true, features = ["single_threaded_async"]}
+web-sys = { workspace = true, features = ["Clipboard", "Window", "Navigator"] }
 web-time = {workspace = true}
 
 [dev-dependencies]

--- a/crates/rmf_site_editor/src/widgets/json_export_menu.rs
+++ b/crates/rmf_site_editor/src/widgets/json_export_menu.rs
@@ -1,0 +1,145 @@
+/*
+ * Copyright (C) 2026 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+use crate::{site::generate_site, AppState, CurrentWorkspace, WorkspaceSaver};
+use bevy::{
+    ecs::{hierarchy::ChildOf, system::SystemState},
+    prelude::*,
+};
+use bevy_egui::{egui, EguiContexts};
+use rmf_site_egui::*;
+
+#[derive(Resource)]
+pub struct JsonExportMenu {
+    export_json: Entity,
+    show_dialog: bool,
+}
+
+impl JsonExportMenu {
+    pub fn get(&self) -> Entity {
+        self.export_json
+    }
+}
+
+impl FromWorld for JsonExportMenu {
+    fn from_world(world: &mut World) -> Self {
+        let file_header = world.resource::<FileMenu>().get();
+        let export_json = world
+            .spawn((
+                MenuItem::Text(TextMenuItem::new("Export Json")),
+                ChildOf(file_header),
+            ))
+            .id();
+
+        JsonExportMenu {
+            export_json,
+            show_dialog: false,
+        }
+    }
+}
+
+fn handle_export_json_menu_events(
+    mut menu_events: EventReader<MenuEvent>,
+    mut json_export: ResMut<JsonExportMenu>,
+) {
+    for event in menu_events.read() {
+        if event.clicked() && event.source() == json_export.get() {
+            json_export.show_dialog = true;
+        }
+    }
+}
+
+fn show_export_json_dialog(mut world: &mut World) {
+    let mut state: SystemState<(Res<JsonExportMenu>, Res<CurrentWorkspace>)> =
+        SystemState::new(world);
+    let (json_export, current_workspace) = state.get_mut(world);
+
+    if !json_export.show_dialog {
+        return;
+    }
+
+    let Some(ws_root) = current_workspace.root else {
+        warn!("Failed saving workspace, no current workspace found");
+        return;
+    };
+
+    let Ok(mut site) = generate_site(world, ws_root)
+        .map_err(|err| error!("Unable to compile site: {err}"))
+        .and_then(|site| {
+            site.to_string_json_pretty()
+                .map_err(|err| error!("Unable to serialize site to JSON: {err}"))
+        })
+    else {
+        return;
+    };
+
+    let mut state: SystemState<EguiContexts> = SystemState::new(world);
+    let mut contexts = state.get_mut(world);
+
+    let mut close_dialog = false;
+    egui::Window::new("Export Site JSON")
+        .collapsible(false)
+        .resizable(false)
+        .anchor(egui::Align2::CENTER_CENTER, [0.0, 0.0])
+        .show(contexts.ctx_mut(), |ui| {
+            egui::ScrollArea::vertical()
+                .max_height(400.0)
+                .show(ui, |ui| {
+                    ui.add(
+                        egui::TextEdit::multiline(&mut site)
+                            .font(egui::TextStyle::Monospace)
+                            .code_editor()
+                            .desired_width(f32::INFINITY),
+                    );
+                });
+            ui.add_space(10.0);
+
+            ui.horizontal(|ui| {
+                ui.with_layout(egui::Layout::left_to_right(egui::Align::Center), |ui| {
+                    if ui.button("Copy to clipboard").clicked() {
+                        ui.ctx().copy_text(site);
+                    }
+                });
+                ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                    if ui.button("Close").clicked() {
+                        close_dialog = true;
+                    }
+                });
+            });
+        });
+
+    if close_dialog {
+        let mut state: SystemState<ResMut<JsonExportMenu>> = SystemState::new(world);
+        let mut json_export = state.get_mut(world);
+        json_export.show_dialog = false;
+    }
+}
+
+#[derive(Default)]
+pub struct JsonExportMenuPlugin {}
+
+impl Plugin for JsonExportMenuPlugin {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<JsonExportMenu>().add_systems(
+            Update,
+            (
+                handle_export_json_menu_events.run_if(AppState::in_displaying_mode()),
+                show_export_json_dialog,
+            ),
+        );
+    }
+}

--- a/crates/rmf_site_editor/src/widgets/json_export_menu.rs
+++ b/crates/rmf_site_editor/src/widgets/json_export_menu.rs
@@ -28,6 +28,31 @@ use wasm_bindgen::prelude::*;
 use web_sys::{Blob, BlobPropertyBag, Clipboard, HtmlAnchorElement, Url, Window};
 
 #[derive(Resource)]
+pub struct DownloadFileMenu {
+    download_file: Entity,
+}
+
+impl DownloadFileMenu {
+    pub fn get(&self) -> Entity {
+        self.download_file
+    }
+}
+
+impl FromWorld for DownloadFileMenu {
+    fn from_world(world: &mut World) -> Self {
+        let file_header = world.resource::<FileMenu>().get();
+        let download_file = world
+            .spawn((
+                MenuItem::Text(TextMenuItem::new("Download File")),
+                ChildOf(file_header),
+            ))
+            .id();
+
+        DownloadFileMenu { download_file }
+    }
+}
+
+#[derive(Resource)]
 pub struct JsonExportMenu {
     export_json: Entity,
     show_dialog: bool,
@@ -54,6 +79,53 @@ impl FromWorld for JsonExportMenu {
             show_dialog: false,
         }
     }
+}
+
+#[derive(Clone, Event)]
+pub struct DownloadSiteFile {
+    pub site_name: String,
+    pub site_str: String,
+}
+
+fn handle_download_file_menu_events(mut world: &mut World) {
+    let mut state: SystemState<(
+        EventReader<MenuEvent>,
+        ResMut<DownloadFileMenu>,
+        Res<CurrentWorkspace>,
+    )> = SystemState::new(world);
+    let (mut menu_events, download_file, current_workspace) = state.get_mut(world);
+    let Some(event) = menu_events.read().last() else {
+        return;
+    };
+    if !(event.clicked() && event.source() == download_file.get()) {
+        return;
+    }
+
+    let Some(ws_root) = current_workspace.root else {
+        warn!("Failed saving workspace, no current workspace found");
+        return;
+    };
+
+    let site = match generate_site(world, ws_root) {
+        Ok(site) => site,
+        Err(err) => {
+            error!("Unable to compile site: {err}");
+            return;
+        }
+    };
+
+    let site_str = match site.to_string_json_pretty() {
+        Ok(json) => json,
+        Err(err) => {
+            error!("Unable to serialize site to JSON: {err}");
+            return;
+        }
+    };
+
+    world.trigger(DownloadSiteFile {
+        site_name: site.properties.name.0.clone(),
+        site_str: site_str.clone(),
+    });
 }
 
 fn handle_export_json_menu_events(
@@ -101,6 +173,7 @@ fn show_export_json_dialog(mut world: &mut World) {
     let mut contexts = state.get_mut(world);
 
     let mut close_dialog = false;
+    let mut download = false;
     egui::Window::new("Export Site JSON")
         .collapsible(false)
         .resizable(false)
@@ -122,7 +195,7 @@ fn show_export_json_dialog(mut world: &mut World) {
                 ui.with_layout(egui::Layout::left_to_right(egui::Align::Center), |ui| {
                     if ui.button("Copy to clipboard").clicked() {
                         #[cfg(not(target_arch = "wasm32"))]
-                        ui.ctx().copy_text(site_str);
+                        ui.ctx().copy_text(site_str.clone());
 
                         #[cfg(target_arch = "wasm32")]
                         if let Some(window) = web_sys::window() {
@@ -131,11 +204,7 @@ fn show_export_json_dialog(mut world: &mut World) {
                     }
                     #[cfg(target_arch = "wasm32")]
                     if ui.button("Download file").clicked() {
-                        if download_site_file(site.properties.name.0.clone(), site_str.clone())
-                            .is_err()
-                        {
-                            error!("Failed to download site JSON file");
-                        }
+                        download = true;
                     }
                 });
                 ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
@@ -146,10 +215,25 @@ fn show_export_json_dialog(mut world: &mut World) {
             });
         });
 
+    if download {
+        world.trigger(DownloadSiteFile {
+            site_name: site.properties.name.0.clone(),
+            site_str: site_str.clone(),
+        });
+    }
+
     if close_dialog {
         let mut state: SystemState<ResMut<JsonExportMenu>> = SystemState::new(world);
         let mut json_export = state.get_mut(world);
         json_export.show_dialog = false;
+    }
+}
+
+fn on_download_site(trigger: Trigger<DownloadSiteFile>) {
+    let event = trigger.event();
+    #[cfg(target_arch = "wasm32")]
+    if download_site_file(event.site_name.clone(), event.site_str.clone()).is_err() {
+        error!("Failed to download site JSON file");
     }
 }
 
@@ -180,12 +264,16 @@ pub struct JsonExportMenuPlugin {}
 
 impl Plugin for JsonExportMenuPlugin {
     fn build(&self, app: &mut App) {
-        app.init_resource::<JsonExportMenu>().add_systems(
-            Update,
-            (
-                handle_export_json_menu_events.run_if(AppState::in_displaying_mode()),
-                show_export_json_dialog,
-            ),
-        );
+        app.init_resource::<JsonExportMenu>()
+            .init_resource::<DownloadFileMenu>()
+            .add_systems(
+                Update,
+                (
+                    handle_export_json_menu_events.run_if(AppState::in_displaying_mode()),
+                    handle_download_file_menu_events.run_if(AppState::in_displaying_mode()),
+                    show_export_json_dialog,
+                ),
+            )
+            .add_observer(on_download_site);
     }
 }

--- a/crates/rmf_site_editor/src/widgets/json_export_menu.rs
+++ b/crates/rmf_site_editor/src/widgets/json_export_menu.rs
@@ -22,6 +22,8 @@ use bevy::{
 };
 use bevy_egui::{egui, EguiContexts};
 use rmf_site_egui::*;
+#[cfg(target_arch = "wasm32")]
+use web_sys::{Clipboard, Window};
 
 #[derive(Resource)]
 pub struct JsonExportMenu {
@@ -111,7 +113,13 @@ fn show_export_json_dialog(mut world: &mut World) {
             ui.horizontal(|ui| {
                 ui.with_layout(egui::Layout::left_to_right(egui::Align::Center), |ui| {
                     if ui.button("Copy to clipboard").clicked() {
+                        #[cfg(not(target_arch = "wasm32"))]
                         ui.ctx().copy_text(site);
+
+                        #[cfg(target_arch = "wasm32")]
+                        if let Some(window) = web_sys::window() {
+                            let _ = window.navigator().clipboard().write_text(&site);
+                        }
                     }
                 });
                 ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {

--- a/crates/rmf_site_editor/src/widgets/json_export_menu.rs
+++ b/crates/rmf_site_editor/src/widgets/json_export_menu.rs
@@ -15,7 +15,7 @@
  *
 */
 
-use crate::{site::generate_site, AppState, CurrentWorkspace, WorkspaceSaver};
+use crate::{site::generate_site, AppState, CurrentWorkspace};
 use bevy::{
     ecs::{hierarchy::ChildOf, system::SystemState},
     prelude::*,
@@ -23,7 +23,9 @@ use bevy::{
 use bevy_egui::{egui, EguiContexts};
 use rmf_site_egui::*;
 #[cfg(target_arch = "wasm32")]
-use web_sys::{Clipboard, Window};
+use wasm_bindgen::prelude::*;
+#[cfg(target_arch = "wasm32")]
+use web_sys::{Blob, BlobPropertyBag, Clipboard, HtmlAnchorElement, Url, Window};
 
 #[derive(Resource)]
 pub struct JsonExportMenu {
@@ -79,14 +81,20 @@ fn show_export_json_dialog(mut world: &mut World) {
         return;
     };
 
-    let Ok(mut site) = generate_site(world, ws_root)
-        .map_err(|err| error!("Unable to compile site: {err}"))
-        .and_then(|site| {
-            site.to_string_json_pretty()
-                .map_err(|err| error!("Unable to serialize site to JSON: {err}"))
-        })
-    else {
-        return;
+    let mut site = match generate_site(world, ws_root) {
+        Ok(site) => site,
+        Err(err) => {
+            error!("Unable to compile site: {err}");
+            return;
+        }
+    };
+
+    let mut site_str = match site.to_string_json_pretty() {
+        Ok(json) => json,
+        Err(err) => {
+            error!("Unable to serialize site to JSON: {err}");
+            return;
+        }
     };
 
     let mut state: SystemState<EguiContexts> = SystemState::new(world);
@@ -102,7 +110,7 @@ fn show_export_json_dialog(mut world: &mut World) {
                 .max_height(400.0)
                 .show(ui, |ui| {
                     ui.add(
-                        egui::TextEdit::multiline(&mut site)
+                        egui::TextEdit::multiline(&mut site_str)
                             .font(egui::TextStyle::Monospace)
                             .code_editor()
                             .desired_width(f32::INFINITY),
@@ -114,11 +122,19 @@ fn show_export_json_dialog(mut world: &mut World) {
                 ui.with_layout(egui::Layout::left_to_right(egui::Align::Center), |ui| {
                     if ui.button("Copy to clipboard").clicked() {
                         #[cfg(not(target_arch = "wasm32"))]
-                        ui.ctx().copy_text(site);
+                        ui.ctx().copy_text(site_str);
 
                         #[cfg(target_arch = "wasm32")]
                         if let Some(window) = web_sys::window() {
-                            let _ = window.navigator().clipboard().write_text(&site);
+                            let _ = window.navigator().clipboard().write_text(&site_str);
+                        }
+                    }
+                    #[cfg(target_arch = "wasm32")]
+                    if ui.button("Download file").clicked() {
+                        if download_site_file(site.properties.name.0.clone(), site_str.clone())
+                            .is_err()
+                        {
+                            error!("Failed to download site JSON file");
                         }
                     }
                 });
@@ -135,6 +151,28 @@ fn show_export_json_dialog(mut world: &mut World) {
         let mut json_export = state.get_mut(world);
         json_export.show_dialog = false;
     }
+}
+
+#[cfg(target_arch = "wasm32")]
+fn download_site_file(site_name: String, site_str: String) -> Result<(), JsValue> {
+    let window = web_sys::window().ok_or("Window not found for download")?;
+    let document = window.document().ok_or("Document not found for download")?;
+    let mut parts = js_sys::Array::new();
+    parts.push(&JsValue::from_str(&site_str));
+    let blob =
+        Blob::new_with_str_sequence_and_options(&parts, BlobPropertyBag::new().type_("text/json"))?;
+    let url = Url::create_object_url_with_blob(&blob)?;
+    let anchor = document
+        .create_element("a")?
+        .dyn_into::<HtmlAnchorElement>()?;
+    anchor.set_href(&url);
+    let filename = site_name + ".site.json";
+    anchor.set_download(&filename);
+    anchor.click();
+
+    Url::revoke_object_url(&url)?;
+
+    Ok(())
 }
 
 #[derive(Default)]

--- a/crates/rmf_site_editor/src/widgets/mod.rs
+++ b/crates/rmf_site_editor/src/widgets/mod.rs
@@ -68,6 +68,9 @@ pub use icons::*;
 pub mod inspector;
 pub use inspector::*;
 
+pub mod json_export_menu;
+pub use json_export_menu::*;
+
 pub mod move_layer;
 pub use move_layer::*;
 
@@ -171,6 +174,8 @@ impl Plugin for StandardUiPlugin {
                 SdfExportMenuPlugin::default(),
                 #[cfg(not(target_arch = "wasm32"))]
                 NavGraphIoPlugin::default(),
+                #[cfg(target_arch = "wasm32")]
+                JsonExportMenuPlugin::default(),
             ))
             .add_systems(Startup, init_ui_style)
             .add_systems(


### PR DESCRIPTION
This PR targets https://github.com/open-rmf/rmf_site/issues/423 and provides a way for users to export their site JSON on web via copy/paste. The objective is to allow users to store changes they made on the web editor.

Currently we do not support saving to file on wasm due to limitations in accessing the file system, so as a workaround this PR generates the site file to JSON string and allows the user to copy it. There could be better alternatives out there and I'm open to suggestions!

One thing to note - [`write_text()`](https://docs.rs/web-sys/0.3.77/web_sys/struct.Clipboard.html#method.write_text) is currently only enabled for secure context (e.g. `https://`, `localhost`), more details [here](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard_API#security_considerations).

CC @JohnTGZ 

### To test

Follow instructions on the main README to run the editor on web. Under `File` in the top menu bar, you'll see an `Export JSON` button. Upon clicking on it a dialog will appear with the JSON string and button to copy all to clipboard.

<img width="1349" height="854" alt="image" src="https://github.com/user-attachments/assets/e60d272b-2e91-4340-bc4a-d1d9d6cbd4fe" />
