### PR TITLE
Fix panel alignment for anchor inspector

### DIFF
--- a/crates/rmf_site_editor/src/widgets/inspector/inspect_anchor.rs
+++ b/crates/rmf_site_editor/src/widgets/inspector/inspect_anchor.rs
@@ -137,45 +137,49 @@ fn impl_inspect_anchor(
                 }
             });
         } else {
-            match anchor {
-                Anchor::Translate2D(_) => {
-                    if !is_dependency {
-                        ui.label("x");
-                    }
-                    let mut x = tf.translation.x;
-                    ui.add(DragValue::new(&mut x).speed(0.01));
+            panel.orthogonal(ui, |ui| {
+                match anchor {
+                    Anchor::Translate2D(_) => {
+                        if !is_dependency {
+                            ui.label("x");
+                        }
+                        let mut x = tf.translation.x;
+                        ui.add(DragValue::new(&mut x).speed(0.01));
 
-                    if !is_dependency {
-                        ui.label("y");
-                    }
-                    let mut y = tf.translation.y;
-                    ui.add(DragValue::new(&mut y).speed(0.01));
+                        if !is_dependency {
+                            ui.label("y");
+                        }
+                        let mut y = tf.translation.y;
+                        ui.add(DragValue::new(&mut y).speed(0.01));
 
-                    if x != tf.translation.x || y != tf.translation.y {
-                        {}
-                        params.move_to.write(MoveTo {
-                            entity: id,
-                            transform: Transform::from_translation([x, y, 0.0].into()),
+                        if x != tf.translation.x || y != tf.translation.y {
+                            {}
+                            params.move_to.write(MoveTo {
+                                entity: id,
+                                transform: Transform::from_translation([x, y, 0.0].into()),
+                            });
+                        }
+                    }
+                    Anchor::CategorizedTranslate2D(_) => {
+                        warn!("Categorized translate inspector not implemented yet");
+                    }
+                    Anchor::Pose3D(pose) => {
+                        panel.align(ui, |ui| {
+                            if let Some(new_pose) = InspectPoseComponent::new(pose).show(ui) {
+                                // TODO(luca) Using moveto doesn't allow switching between variants of
+                                // Pose3D
+                                params.move_to.write(MoveTo {
+                                    entity: id,
+                                    transform: new_pose.transform(),
+                                });
+                            }
                         });
                     }
                 }
-                Anchor::CategorizedTranslate2D(_) => {
-                    warn!("Categorized translate inspector not implemented yet");
-                }
-                Anchor::Pose3D(pose) => {
-                    panel.align(ui, |ui| {
-                        if let Some(new_pose) = InspectPoseComponent::new(pose).show(ui) {
-                            // TODO(luca) Using moveto doesn't allow switching between variants of
-                            // Pose3D
-                            params.move_to.write(MoveTo {
-                                entity: id,
-                                transform: new_pose.transform(),
-                            });
-                        }
-                    });
-                }
-            }
+            });
         }
+
+        ui.add_space(10.0);
     }
 
     Some(InspectAnchorResponse { replace })
@@ -214,8 +218,8 @@ impl<'w, 's> WidgetSystem<Inspect> for InspectAnchorDependents<'w, 's> {
             }
         }
 
-        panel.align(ui, |ui| {
-            ui.heading("Dependencies");
+        panel.flush().align(ui, |ui| {
+            ui.heading("Dependents");
             for (category, entities) in &category_map {
                 ui.label(category.label());
                 for e in entities {

--- a/crates/rmf_site_editor/src/widgets/inspector/inspect_anchor.rs
+++ b/crates/rmf_site_editor/src/widgets/inspector/inspect_anchor.rs
@@ -179,7 +179,13 @@ fn impl_inspect_anchor(
             });
         }
 
-        ui.add_space(10.0);
+        if !is_dependency {
+            // When inspecting an anchor, this adds some breathing room from the
+            // InspectAnchorDependents widget. When this is instead for a
+            // dependency, we skip adding the space because this widget will be
+            // integrated into a grid.
+            ui.add_space(10.0);
+        }
     }
 
     Some(InspectAnchorResponse { replace })

--- a/crates/rmf_site_egui/src/panel/mod.rs
+++ b/crates/rmf_site_egui/src/panel/mod.rs
@@ -266,6 +266,12 @@ impl PanelSettings {
         self
     }
 
+    /// Turn off the centered property, if it is on
+    pub fn flush(mut self) -> Self {
+        self.alignment.centered = false;
+        self
+    }
+
     pub fn is_horizontal(&self) -> bool {
         self.side.is_horizontal()
     }


### PR DESCRIPTION
I noticed alignment for the anchor inspector widget was out of whack:

<img width="285" height="215" alt="site_editor_bad_formatting" src="https://github.com/user-attachments/assets/22b84feb-430e-4f3a-ad4f-622ba39f9267" />

This probably happened after #424 and just wasn't noticed until now. This PR fixes the alignment:

<img width="284" height="203" alt="site_editor_fixed_formatting" src="https://github.com/user-attachments/assets/3c0f4a72-5f9b-41e7-932f-59b3f0574f87" />

Also the the anchor dependents inspector widget was wrongly labeled as "Dependencies". This corrects it to "Dependents", because it lists items that depend on the currently selected anchor.