### PR TITLE
Update StandardMaterial used for lane shader

### DIFF
--- a/crates/rmf_site_editor/src/site/lane.rs
+++ b/crates/rmf_site_editor/src/site/lane.rs
@@ -199,7 +199,7 @@ pub fn add_lane_visuals(
                 MeshMaterial3d(extended_materials.add(ExtendedMaterial {
                     base: StandardMaterial {
                         depth_bias: 3.0,
-                        ..default()
+                        ..old_default_material(lane_color.into())
                     },
                     extension: assets::LaneArrowMaterial {
                         single_arrow_color: forward_arrow_color(lane_color),


### PR DESCRIPTION
## Bug fix
Difference in material glossiness for lane shader found in #394 
<img width="522" height="475" alt="image" src="https://github.com/user-attachments/assets/e6e5f87e-356c-4b80-a11c-5feebe70ec39" />

### Fix applied
The fix proposed in the original bug report is to update the material properties in the old_default_material to match the shader, but updating the lane shader material to use the same material as all the other lane components (outline, unselected/unhovered lane material, rounded ends) seems more reasonable. I've updated the standard material in the lane shader to also use the same old_default_material(...) used for the rounded ends.

<img width="646" height="672" alt="Screenshot 2026-08-12 at 12 01 28 PM" src="https://github.com/user-attachments/assets/bb0cf4f9-9a0e-43cd-80aa-23a381ce91a9" />
